### PR TITLE
Fix Error Analysis collected error label

### DIFF
--- a/CSSampleApp/src/main/res/values/strings.xml
+++ b/CSSampleApp/src/main/res/values/strings.xml
@@ -25,7 +25,7 @@
     <string name="label_timeout_button">Timeout</string>
     <string name="label_custom_variables">Custom Variables</string>
     <string name="label_dynamic_variables">Dynamic Variables</string>
-    <string name="label_behaviour_hint"><![CDATA[Response code >= 300 will be capture as an error]]></string>
+    <string name="label_behaviour_hint"><![CDATA[Response code >= 400 will be capture as an error]]></string>
     <string name="first_fragment">First Fragment</string>
     <string name="second_fragment">Second Fragment</string>
     <string name="third_fragment">Third Fragment</string>


### PR DESCRIPTION
Fix a misleading label indicating that API Errors above 300 are collected (while it's 400 as indicated in https://docs.contentsquare.com/android-sdk-error-analysis/#collected-data-points)