### PR TITLE
feat(e&r): add CI workflow and credentials from different sources

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # Step 2: Set up JDK 11 (required for Gradle)
-      - name: Set up JDK 11
+      # Step 2: Set up JDK 17 (required for Gradle)
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '17'
 
       # Step 3: Cache Gradle dependencies
       - name: Cache Gradle dependencies

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
         env:
-          PROD_SAMPLE_PROJECT_ID: ${{ secrets.PROD_SAMPLE_PROJECT_ID }}
-          PROD_MAPPING_UPLOAD_CLIENT_ID: ${{ secrets.PROD_MAPPING_UPLOAD_CLIENT_ID }}
-          PROD_MAPPING_UPLOAD_CLIENT_SECRET: ${{ secrets.PROD_MAPPING_UPLOAD_CLIENT_SECRET }}
+          SAMPLE_PROJECT_ID: ${{ secrets.SAMPLE_PROJECT_ID }}
+          SAMPLE_MAPPING_UPLOAD_CLIENT_ID: ${{ secrets.SAMPLE_MAPPING_UPLOAD_CLIENT_ID }}
+          SAMPLE_MAPPING_UPLOAD_CLIENT_SECRET: ${{ secrets.SAMPLE_MAPPING_UPLOAD_CLIENT_SECRET }}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,49 @@
+name: Android CI
+
+# Triggers the workflow on push to the main branch or on pull requests
+on:
+  push:
+    branches:
+      - master
+      - feat/ci-workflow
+  pull_request:
+    branches:
+      - master
+      - feat/ci-workflow
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Checkout the repository code
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Step 2: Set up JDK 11 (required for Gradle)
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+
+      # Step 3: Cache Gradle dependencies
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # Step 4: Build the project using Gradle
+      - name: Build with Gradle
+        run: ./gradlew build
+        env:
+          PROD_MAPPING_UPLOAD_CLIENT_ID: ${{ secrets.PROD_MAPPING_UPLOAD_CLIENT_ID }}
+          PROD_MAPPING_UPLOAD_CLIENT_SECRET: ${{ secrets.PROD_MAPPING_UPLOAD_CLIENT_SECRET }}
+
+      # Optional Step: Run your tests
+      - name: Run tests
+        run: ./gradlew test

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -5,11 +5,9 @@ on:
   push:
     branches:
       - master
-      - feat/ci-workflow
   pull_request:
     branches:
       - master
-      - feat/ci-workflow
 
 jobs:
   build:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
         env:
+          PROD_SAMPLE_PROJECT_ID: ${{ secrets.PROD_SAMPLE_PROJECT_ID }}
           PROD_MAPPING_UPLOAD_CLIENT_ID: ${{ secrets.PROD_MAPPING_UPLOAD_CLIENT_ID }}
           PROD_MAPPING_UPLOAD_CLIENT_SECRET: ${{ secrets.PROD_MAPPING_UPLOAD_CLIENT_SECRET }}
-
-      # Optional Step: Run your tests
-      - name: Run tests
-        run: ./gradlew test

--- a/CSSampleApp/build.gradle
+++ b/CSSampleApp/build.gradle
@@ -28,13 +28,13 @@ android {
             errorAnalysisCrash {
                 uploadCredentials {
                     // from gradle.properties
-                    projectId = project.findProperty("PROD_SAMPLE_PROJECT_ID")?.toInteger() ?:
-                            System.getenv("PROD_SAMPLE_PROJECT_ID")?.toInteger()
+                    projectId = project.findProperty("SAMPLE_PROJECT_ID")?.toInteger() ?:
+                            System.getenv("SAMPLE_PROJECT_ID")?.toInteger()
                     // from local.properties
-                    clientId = getLocalProperty("PROD_MAPPING_UPLOAD_CLIENT_ID") ?:
-                            System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID")
+                    clientId = getLocalProperty("SAMPLE_MAPPING_UPLOAD_CLIENT_ID") ?:
+                            System.getenv("SAMPLE_MAPPING_UPLOAD_CLIENT_ID")
                     // from environment variable, is the same than Github CI here
-                    clientSecret = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_SECRET") ?: ""
+                    clientSecret = System.getenv("SAMPLE_MAPPING_UPLOAD_CLIENT_SECRET") ?: ""
                 }
             }
         }

--- a/CSSampleApp/build.gradle
+++ b/CSSampleApp/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 android {
     compileSdk 35
-
+    def csProjectId = 5671
     defaultConfig {
         applicationId "com.example.androidsampleapp"
         minSdk 21
@@ -25,12 +25,26 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            errorAnalysisCrash {
+                uploadCredentials {
+                    projectId = csProjectId
+                    clientId = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID") ?: ""
+                    clientSecret = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_SECRET") ?: ""
+                }
+            }
         }
 
         minify {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.debug
+            errorAnalysisCrash {
+                uploadCredentials {
+                    projectId = csProjectId
+                    clientId = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID") ?: ""
+                    clientSecret = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_SECRET") ?: ""
+                }
+            }
         }
     }
 

--- a/CSSampleApp/build.gradle
+++ b/CSSampleApp/build.gradle
@@ -8,7 +8,6 @@ plugins {
 
 android {
     compileSdk 35
-    def csProjectId = 5671
     defaultConfig {
         applicationId "com.example.androidsampleapp"
         minSdk 21
@@ -25,23 +24,17 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            // Set credentials from different source, fallback on Github CI --> see android-ci.yml
+            def localProperties = getLocalProperties()
             errorAnalysisCrash {
                 uploadCredentials {
-                    projectId = csProjectId
-                    clientId = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID") ?: ""
-                    clientSecret = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_SECRET") ?: ""
-                }
-            }
-        }
-
-        minify {
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.debug
-            errorAnalysisCrash {
-                uploadCredentials {
-                    projectId = csProjectId
-                    clientId = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID") ?: ""
+                    // from gradle.properties
+                    projectId = project.findProperty("PROD_SAMPLE_PROJECT_ID")?.toInteger() ?:
+                            System.getenv("PROD_SAMPLE_PROJECT_ID")
+                    // from local.properties
+                    clientId = localProperties.getProperty("PROD_MAPPING_UPLOAD_CLIENT_ID", "") ?:
+                            System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID")
+                    // from environment variable, is the same than Github CI here
                     clientSecret = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_SECRET") ?: ""
                 }
             }
@@ -97,4 +90,14 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+}
+
+def getLocalProperties() {
+    def localProperties = new Properties()
+    def localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        localProperties.load(new FileInputStream(localPropertiesFile))
+        return localProperties
+    }
+    return null
 }

--- a/CSSampleApp/build.gradle
+++ b/CSSampleApp/build.gradle
@@ -25,17 +25,25 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             // Set credentials from different source, fallback on Github CI --> see android-ci.yml
-            def localProperties = getLocalProperties()
+//            def localProperties = getLocalProperties()
+            // from gradle.properties
+            def projectIdFromGradleFile = project.findProperty("PROD_SAMPLE_PROJECT_ID")?.toInteger() ?:
+                    System.getenv("PROD_SAMPLE_PROJECT_ID")?.toInteger()
+            // from local.properties
+            def clientIdFromLocal = getLocalProperty("PROD_MAPPING_UPLOAD_CLIENT_ID") ?: System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID")
+//            if (localProperties != null) localProperties.getProperty("PROD_MAPPING_UPLOAD_CLIENT_ID", "") else
+//                System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID")
+            // from environment variable, is the same than Github CI here
+            def clientSecretFromEnv = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_SECRET") ?: ""
+            println("project id = ${projectIdFromGradleFile} client id = ${clientIdFromLocal} client secret = ${clientSecretFromEnv}")
             errorAnalysisCrash {
                 uploadCredentials {
                     // from gradle.properties
-                    projectId = project.findProperty("PROD_SAMPLE_PROJECT_ID")?.toInteger() ?:
-                            System.getenv("PROD_SAMPLE_PROJECT_ID")?.toInteger()
+                    projectId = projectIdFromGradleFile
                     // from local.properties
-                    clientId = localProperties.getProperty("PROD_MAPPING_UPLOAD_CLIENT_ID", "") ?:
-                            System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID")
+                    clientId = clientIdFromLocal
                     // from environment variable, is the same than Github CI here
-                    clientSecret = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_SECRET") ?: ""
+                    clientSecret = clientSecretFromEnv
                 }
             }
         }
@@ -92,12 +100,12 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }
 
-def getLocalProperties() {
+def getLocalProperty(clientIdProp) {
     def localProperties = new Properties()
     def localPropertiesFile = rootProject.file("local.properties")
     if (localPropertiesFile.exists()) {
         localProperties.load(new FileInputStream(localPropertiesFile))
-        return localProperties
+        return localProperties.getProperty(clientIdProp)
     }
     return null
 }

--- a/CSSampleApp/build.gradle
+++ b/CSSampleApp/build.gradle
@@ -25,25 +25,16 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             // Set credentials from different source, fallback on Github CI --> see android-ci.yml
-//            def localProperties = getLocalProperties()
-            // from gradle.properties
-            def projectIdFromGradleFile = project.findProperty("PROD_SAMPLE_PROJECT_ID")?.toInteger() ?:
-                    System.getenv("PROD_SAMPLE_PROJECT_ID")?.toInteger()
-            // from local.properties
-            def clientIdFromLocal = getLocalProperty("PROD_MAPPING_UPLOAD_CLIENT_ID") ?: System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID")
-//            if (localProperties != null) localProperties.getProperty("PROD_MAPPING_UPLOAD_CLIENT_ID", "") else
-//                System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID")
-            // from environment variable, is the same than Github CI here
-            def clientSecretFromEnv = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_SECRET") ?: ""
-            println("project id = ${projectIdFromGradleFile} client id = ${clientIdFromLocal} client secret = ${clientSecretFromEnv}")
             errorAnalysisCrash {
                 uploadCredentials {
                     // from gradle.properties
-                    projectId = projectIdFromGradleFile
+                    projectId = project.findProperty("PROD_SAMPLE_PROJECT_ID")?.toInteger() ?:
+                            System.getenv("PROD_SAMPLE_PROJECT_ID")?.toInteger()
                     // from local.properties
-                    clientId = clientIdFromLocal
+                    clientId = getLocalProperty("PROD_MAPPING_UPLOAD_CLIENT_ID") ?:
+                            System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID")
                     // from environment variable, is the same than Github CI here
-                    clientSecret = clientSecretFromEnv
+                    clientSecret = System.getenv("PROD_MAPPING_UPLOAD_CLIENT_SECRET") ?: ""
                 }
             }
         }

--- a/CSSampleApp/build.gradle
+++ b/CSSampleApp/build.gradle
@@ -30,7 +30,7 @@ android {
                 uploadCredentials {
                     // from gradle.properties
                     projectId = project.findProperty("PROD_SAMPLE_PROJECT_ID")?.toInteger() ?:
-                            System.getenv("PROD_SAMPLE_PROJECT_ID")
+                            System.getenv("PROD_SAMPLE_PROJECT_ID")?.toInteger()
                     // from local.properties
                     clientId = localProperties.getProperty("PROD_MAPPING_UPLOAD_CLIENT_ID", "") ?:
                             System.getenv("PROD_MAPPING_UPLOAD_CLIENT_ID")


### PR DESCRIPTION
We have a support ticket from a client struggling to set up credentials. 
This PR is here to show different way of implementing it, with a fallback on Github CI variables so PR doesn't fail on our CI.